### PR TITLE
Some fixes to be able to use arm2d headers from CPP side.

### DIFF
--- a/Library/Include/arm_2d_conversion.h
+++ b/Library/Include/arm_2d_conversion.h
@@ -175,9 +175,9 @@ __STATIC_INLINE uint16_t __arm_2d_rgb565_pack(__arm_2d_color_fast_rgb_t * ptRGB)
     assert(NULL != ptRGB);
     
     arm_2d_color_rgb565_t tOutput = {
-        .u5R = (uint16_t) ptRGB->R >> 3,
-        .u6G = (uint16_t) ptRGB->G >> 2,
-        .u5B = (uint16_t) ptRGB->B >> 3,
+        .u5B = (uint16_t) (ptRGB->B >> 3),
+        .u6G = (uint16_t) (ptRGB->G >> 2),
+        .u5R = (uint16_t) (ptRGB->R >> 3),
     };
     return tOutput.tValue;
 }
@@ -194,9 +194,9 @@ __STATIC_INLINE uint32_t __arm_2d_cccn888_pack(__arm_2d_color_fast_rgb_t * ptRGB
     assert(NULL != ptRGB);
     
     arm_2d_color_bgra8888_t tOutput = {
-        .u8R = (uint16_t) ptRGB->R,
-        .u8G = (uint16_t) ptRGB->G,
         .u8B = (uint16_t) ptRGB->B,
+        .u8G = (uint16_t) ptRGB->G,
+        .u8R = (uint16_t) ptRGB->R,
         .u8A = (uint16_t) ptRGB->A,
     };
     return tOutput.tValue;

--- a/Library/Include/arm_2d_utils.h
+++ b/Library/Include/arm_2d_utils.h
@@ -64,7 +64,17 @@
 /*! \note arm-2d relies on CMSIS 5.8.0 and above.
  */
 #if __IS_SUPPORTED_ARM_ARCH__
+
+#ifdef   __cplusplus
+extern "C" {
+#endif
+
 #   include "cmsis_compiler.h"
+
+#ifdef   __cplusplus
+}
+#endif
+
 #else
 #   include "arm_2d_user_arch_port.h"
 #endif


### PR DESCRIPTION
The fixes are removing compilation errors and compilation warnings when building on Pico and the Arm-2D headers are included from a CPP file.