### PR TITLE
解决gcc提示undefined reference to `clock_gettime'的问题

### DIFF
--- a/examples/[template][pc][vscode]/Makefile
+++ b/examples/[template][pc][vscode]/Makefile
@@ -77,6 +77,7 @@ CCFLAG  +=  -Wno-macro-redefined
 CCFLAG  += 	-Ofast
 CCFLAG  +=  -flto
 LDFLAG  +=  -flto
+LDFLAG  +=  -lpthread
 
 #================================== DO NOT MODIFY UNLESS YOU KNOW THE CONSEQUENCES ====================================#
 .DEFAULT_GOAL = all


### PR DESCRIPTION
估计是电脑环境的问题，部分电脑需要手动添加"-pthread"选项来告知编译器链接相应的库文件