### PR TITLE
Fix typo

### DIFF
--- a/Library/Source/__arm_2d_tile_copy_with_source_mask_and_opacity_helium.c
+++ b/Library/Source/__arm_2d_tile_copy_with_source_mask_and_opacity_helium.c
@@ -717,7 +717,7 @@ void __MVE_WRAPPER(__arm_2d_impl_ccca8888_tile_copy_to_gray8_with_src_chn_mask)(
         const uint8_t  *__RESTRICT pSource = (const uint8_t *) pwSourceBase;
         uint8_t *__RESTRICT pchTarget = pchTargetBase;
         uint8_t *__RESTRICT pwSourceMaskLine = ( uint8_t *__RESTRICT)pwSourceMask;
-#ifdef USE_MVE_INTRINSICSs
+#ifdef USE_MVE_INTRINSICS
         int32_t         blkCnt = iWidth;
         uint16x8_t      vStride4Offs = vidupq_n_u16(0, 4);
 


### PR DESCRIPTION
I encountered this error when building the library with arm-none-eabi-gcc 14.2.0:
> Error: bad element type for instruction -- `vstrb.u16 q7,[r3],#8'

I found that the above arm gcc compilation error is caused by this typo. (build failed with MVE assembly code)
I can build successfully with MVE intrinsic code after fixing this typo.

(Related to https://github.com/ARM-software/Arm-2D/discussions/56)